### PR TITLE
feat: update terminology in CIP and VPP

### DIFF
--- a/specifications/credential.issuance.protocol.md
+++ b/specifications/credential.issuance.protocol.md
@@ -11,7 +11,7 @@ This specification relies on sections [[[#identity-protocol-base]]] and
 
 ### Motivation
 
-Verifiable Credentials enable a holder to present claims directly to a Relying Party (RP) without
+Verifiable Credentials enable a holder to present claims directly to a Verifier without
 the involvement or knowledge of the `Credential Issuer`. The Credential Issuance Protocol (CIP) provides an
 interoperable mechanism for parties (potential holders) to request credentials from a `Credential Issuer.` The protocol
 is designed to handle use cases where credentials can automatically be issued and where a manual workflow is required.
@@ -24,6 +24,16 @@ associated with manual workflows that are best modelled using asynchronous messa
 
 ### Terms
 
+- **Credential Service** - A network-accessible service that manages identity resources.
+- **Resource** - A resource is an entity managed by the Credential Service such as a Verifiable Credential (
+  VC) or Verifiable Presentation (VP).
+- **Holder** - An entity that possesses a set of identity resources as defined by
+    the W3C [[[vc-data-model]]]. The holder will typically be the subject of
+    a VC.
+- **Verifier** - An entity that receives one or more VCs, optionally presented inside a VP as defined by
+  the W3C [[[vc-data-model]]].
+- **Subject** - The target of a set of claims contained in a VC as defined by
+  the [[[vc-data-model]]]. In a dataspace, a subject will be a participant.
 - ***DID*** - A decentralized identifier as defined by [[[did-core]]].
 
 ## Overview

--- a/specifications/verifiable.presentation.protocol.md
+++ b/specifications/verifiable.presentation.protocol.md
@@ -23,11 +23,13 @@ issued credentials.
 ### Terms
 
 - **Credential Service** - A network-accessible service that manages identity resources.
+- **Resource** - A resource is an entity managed by the Credential Service such as a Verifiable Credential (
+  VC) or Verifiable Presentation (VP).
 - **Holder** - An entity that possesses a set of identity resources as defined by
   the W3C [[[vc-data-model]]]. The holder will typically be the subject of
   a VC.
-- **Resource** - A resource is an entity managed by the Credential Service such as a Verifiable Credential (
-  VC) or Verifiable Presentation (VP).
+- **Verifier** - An entity that receives one or more VCs, optionally presented inside a VP as defined by
+  the W3C [[[vc-data-model]]].
 - **Subject** - The target of a set of claims contained in a VC as defined by
   the [[[vc-data-model]]]. In a dataspace, a subject will be a participant.
 - ***DID*** - A decentralized identifier as defined by [[[did-core]]].
@@ -252,7 +254,7 @@ the following properties:
 
 ## CS Endpoint Resolution through DID Documents
 
-Different methods may be used by a Relying Party (as defined by the OAuth2 specification, link TBD) to resolve the
+Different methods may be used by a Verifier to resolve the
 Credential Service for a client. One way is through DID documents. If a DID document is used, the client `DID document`
 MUST contain at least one `Service` entry ([[did-core]], sect. 5.4) of type `CredentialService`:
 


### PR DESCRIPTION
## WHAT

The terminology between the CIP and VPP was inconsistent. Also the term Relying Party (RP) should be replaced with Verifier to align it with the [DID specification](https://www.w3.org/TR/vc-data-model/#dfn-verifier)

Closes #58

## How was the issue fixed?

The Terms section in CIP and VPP were aligned to be similar and the term Verifier has been added to this section. The term RP was substituted with Verifier as discussed in #58.